### PR TITLE
enable autoplaying audio

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivityNative.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivityNative.kt
@@ -335,6 +335,7 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver {
         webSettings?.pluginState = WebSettings.PluginState.ON
         webSettings?.setRenderPriority(WebSettings.RenderPriority.HIGH);
        // webSettings?.cacheMode = WebSettings.LOAD_NO_CACHE;
+        webSettings?.mediaPlaybackRequiresUserGesture = false;
 
         if (userAgent.isNotEmpty()) {
             webSettings?.userAgentString = userAgent


### PR DESCRIPTION
Playing audio usually requires a user interaction first. This patch changes the webviews settings and sets mediaPlaybackRequiresUserGesture to false, which allows audio to be played without an user interaction.