### PR TITLE
Handle all possible MQTT disconnect exceptions

### DIFF
--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/network/MQTT3Service.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/network/MQTT3Service.kt
@@ -226,7 +226,6 @@ class MQTT3Service(
                     Timber.e(e)
                 } catch (e: Mqtt3MessageException) {
                     Timber.e("Error Sending Command: %s", e.message)
-                    e.printStackTrace()
                     listener?.handleMqttException("Couldn't send message to the MQTT broker for topic ${mqttMessage.topic}, check the MQTT client settings or your connection to the broker.")
                 }
             }
@@ -248,10 +247,8 @@ class MQTT3Service(
                         )
                     }
                 } catch (e: NullPointerException) {
-                    e.printStackTrace()
                     Timber.e(e)
                 } catch (e: Mqtt3MessageException) {
-                    e.printStackTrace()
                     Timber.e(e)
                     listener?.handleMqttException("Exception while subscribing: " + e.message)
                 }

--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/network/MQTT5Service.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/network/MQTT5Service.kt
@@ -234,10 +234,8 @@ class MQTT5Service(
                         )
                     }
                 } catch (e: NullPointerException) {
-                    e.printStackTrace()
                     Timber.e(e)
                 } catch (e: Mqtt5MessageException) {
-                    e.printStackTrace()
                     Timber.e(e)
                     listener?.handleMqttException("Exception while subscribing: " + e.message)
                 }


### PR DESCRIPTION
This PR improves the handling of MQTT disconnects.
Previously, only Mqtt3DisconnectException and Mqtt5DisconnectException were handled.

- **ConnectionFailedException** if a connect attempt failed.
- **Mqtt3ConnAckException** or **Mqtt5ConnAckException** (depending on the MQTT version of the client) if the ConnAck message contained an error code, which means that the connect was rejected.
- **ConnectionClosedException** if the connection was closed without sending a Disconnect message (use getSource() to determine if the server or the client closed the connection).
- **Mqtt3DisconnectException** or **Mqtt5DisconnectException** (depending on the MQTT version of the client) if the connection was closed with a Disconnect message (use getSource() to determine if the server, the user or the client sent the Disconnect message).

This PR probably fixes #39 and #40.