### PR TITLE
Update discovery configs to be compatible with Home Assistant's expectations

### DIFF
--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/network/WallPanelService.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/network/WallPanelService.kt
@@ -810,7 +810,7 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
 
     private fun getSensorDiscoveryDef(displayName: String, stateTopic: String, deviceClass: String?, unit: String?, sensorId: String): JSONObject {
         val discoveryDef = JSONObject()
-        discoveryDef.put("name", "${configuration.mqttDiscoveryDeviceName} ${displayName}")
+        discoveryDef.put("name", "${displayName}")
         discoveryDef.put("state_topic", "${configuration.mqttBaseTopic}${stateTopic}")
         if (unit != null) {
             discoveryDef.put("unit_of_measurement", unit)
@@ -828,7 +828,7 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
 
     private fun getBinarySensorDiscoveryDef(displayName: String, stateTopic: String, fieldName: String, deviceClass: String, sensorId: String): JSONObject {
         val discoveryDef = JSONObject()
-        discoveryDef.put("name", "${configuration.mqttDiscoveryDeviceName} ${displayName}")
+        discoveryDef.put("name", "${displayName}")
         discoveryDef.put("state_topic", "${configuration.mqttBaseTopic}${stateTopic}")
         discoveryDef.put("payload_on", true)
         discoveryDef.put("payload_off", false)


### PR DESCRIPTION
In 2024, Home Assistant will stop handling names in discovered MQTT sensors as it currently does. 

Currently, it strips the device name prefix from the config in order to abide by it's entity name expectations. This will be deprecated and removed in 2024. [Here's the relevant post from them.](https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/)

This is a simple fix and resolves the issue. I've tested this with my personal home assistant install by doing the following:
1. Build the project and run in an emulator. I commented out the gradle plugins for google services and crashlytics, and updated my local.properties to include the required parameters for gradle (code, hassUrl, broker, brokerUsername, brokerPass).
2. Connect it to home assistant as you would normally. Go to home assistant, restart all services (I rebooted the host through System -> Power button -> Advanced -> Reboot system. I wasn't able to get the supervisor repair system to re-run properly to show the error without doing this.
3. Notice that the warning about the entity name change shows up
4. Make the changes in this diff, re-run the application in the emulator
5. Reboot Home Assistant again (as done in step 2) and notice that the errors go away

Closes #90 