### PR TITLE
fix: check isInitialized on lateinit prop

### DIFF
--- a/WallPanelApp/src/main/java/xyz/wallpanel/app/utils/InternalWebClient.kt
+++ b/WallPanelApp/src/main/java/xyz/wallpanel/app/utils/InternalWebClient.kt
@@ -83,6 +83,7 @@ open class InternalWebClient(val resources: Resources, private val callback: Web
                     resources.getString(R.string.dialog_message_ssl_not_yet_valid)
             }
             message += resources.getString(xyz.wallpanel.app.R.string.dialog_message_ssl_continue)
+            if (dialogUtils.isInitialized) {
             dialogUtils.showAlertDialog(view.context,
                 resources.getString(R.string.dialog_title_ssl_error),
                 resources.getString(R.string.dialog_message_ssl_continue),
@@ -90,6 +91,7 @@ open class InternalWebClient(val resources: Resources, private val callback: Web
                 { _, _ -> handler.proceed() },
                 { _, _ -> handler.proceed() }
             )
+            }
         } else {
             handler.proceed()
         }


### PR DESCRIPTION
fix for 
```
FATAL EXCEPTION: main
11-08 17:57:48.587  9310  9310 E AndroidRuntime: Process: xyz.wallpanel.app, PID: 9310 11-08 17:57:48.587  9310  9310 E AndroidRuntime: kotlin.UninitializedPropertyAccessException: lateinit property dialogUtils has not been initialized
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at xyz.wallpanel.app.utils.InternalWebClient.getDialogUtils(InternalWebClient.kt:24)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at xyz.wallpanel.app.utils.InternalWebClient.onReceivedSslError(InternalWebClient.kt:86)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at WV.M6.run(chromium-TrichromeWebViewGoogle.aab-stable-599311131:182)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:883)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:100)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:214)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7403)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:502)
11-08 17:57:48.587  9310  9310 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:980)
```